### PR TITLE
Исправления по документации MAX API

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ SDK обрабатывает различные форматы ошибок от
 
 ### Базовый URL API
 
-По умолчанию SDK использует базовый URL API: `https://botapi.max.ru/`
+По умолчанию SDK использует базовый URL API: `https://platform-api.max.ru/`
 
 ### Кастомный HTTP клиент
 

--- a/src/Client/Modules/Chats/Chats.php
+++ b/src/Client/Modules/Chats/Chats.php
@@ -149,11 +149,16 @@ class Chats extends CommonModule
         ?int $marker = null,
         int $count = 20
     ): ChatMemberListResponse {
-        $response = $this->getRequest('/chats/' . $chat_id . '/members', [
-            'user_ids' => implode(',', $user_ids),
+        $params = [
             'marker' => $marker,
-            'count' => $count
-        ]);
+            'count' => $count,
+        ];
+
+        if ($user_ids !== null) {
+            $params['user_ids'] = implode(',', $user_ids);
+        }
+
+        $response = $this->getRequest('/chats/' . $chat_id . '/members', $params);
 
         return new ChatMemberListResponse($response);
     }

--- a/src/Client/Modules/Messages/Messages.php
+++ b/src/Client/Modules/Messages/Messages.php
@@ -92,9 +92,7 @@ class Messages extends CommonModule
     public function getById(string $message_id): Message
     {
         return new Message(
-            $this->getRequest('/messages/' . $message_id, [
-                'message_id' => $message_id,
-            ])
+            $this->getRequest('/messages/' . $message_id)
         );
     }
 
@@ -112,9 +110,10 @@ class Messages extends CommonModule
     ): ResultResponse {
         return new ResultResponse(
             $this->postRequest('/answers', [
-                'callback_id' => $callback_id,
                 'message' => $message,
                 'notification' => $notification,
+            ], [
+                'callback_id' => $callback_id,
             ])
         );
     }


### PR DESCRIPTION
## Summary
- `answerCallback()`: `callback_id` перенесён из body в query параметры (по документации)
- `getById()`: убран дублирующий query-параметр `message_id` (уже в URL)
- `getMembers()`: исправлен `TypeError` при `user_ids=null` (`implode` от `null`)
- README: исправлен базовый URL API (`botapi.max.ru` → `platform-api.max.ru`)